### PR TITLE
Fix watch process exit when file deleted

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,8 @@ module.exports = function(options) {
 
       watcher.on('change', function (event) {
         if (event.type === 'deleted') {
-          delete cached.caches['modules' + prefix][event.path];
-          remember.forget('modules' + prefix, event.path);
+          delete cached.caches.modules[event.path];
+          remember.forget('modules', event.path);
         }
       });
     }


### PR DESCRIPTION
it seems fixes #4 
but sometimes gulp-remember trows warnings:

```
gulp-remember - .forget() warning: file /path/to/src/somefile.js not found in cache modules
```

but that does not break the watch process.